### PR TITLE
Remove background refresh of Votes

### DIFF
--- a/app/admin/campaign_routes.py
+++ b/app/admin/campaign_routes.py
@@ -69,7 +69,7 @@ def campaign_view(campaign_id):
         statuses = CampaignStatus
         candidates = CampaignCandidate.query.filter(CampaignCandidate.campaign_id == c.id)
         projects_list = Project.query.join(Nomination, Project.id == Nomination.project_id).add_column(func.count(Nomination.project_id).label("nomination_count")).group_by(Nomination.project_id).order_by(desc('nomination_count'))
-        print(projects_list)
+
         projects = []
         statuses = []
 

--- a/app/templates/campaign_details.html
+++ b/app/templates/campaign_details.html
@@ -46,8 +46,8 @@
 		    voteText = '';
 		    console.log(data)
 		    for(vote in data) {
-		 	console.log(data[vote].id)
 		 	row++
+			console.log(row)
 		 	voteText += "<tr>";
 		 	voteText += "<td>" + row + "</td>";
 		 	for(project in data[vote].votes) {
@@ -81,7 +81,7 @@
 	    };
 
 
-		var refreshInterval = setInterval(fetchVotes, 30 * 1000);
+		// var refreshInterval = setInterval(fetchVotes, 30 * 1000);
 		fetchVotes();
 
 		$('#campaign_form').submit(function (e) {
@@ -236,7 +236,11 @@
 	</div>
 	<div class="container" id="results">
 		<h5>Voting Results</h5>
-		<table id="results"><thead></thead><tbody></tbody></table>
+		<table id="results">
+		  <thead></thead>
+		  <tbody>
+		  </tbody>
+		</table>
 	</div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
due to our use of Shibboleth, the background fetches of votes loses
CORS headers after a few moments. This removes that recurring refresh
and only fetches once on page load.

This resolves jh-ospo/foss-fund/#4